### PR TITLE
Only set the code when the document has changed

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -48,10 +48,12 @@ y`;
   const [open, setOpen] = useState(false);
   const [editorRef] = useCodeMirror({
     text: initialCode,
-    // Dispatches the input from the CodeMirror editor
-    dispatch: (code: string) => {},
+    // When the editor changes code, this callback is triggered with the current code
+    setCode: (code: string) => {},
   });
-  const [runSnippet, { data }] = useMutation(RUN_SNIPPET_MUTATION);
+  const [runSnippet, { data }] = useMutation(RUN_SNIPPET_MUTATION, {
+    variables: {},
+  });
 
   const handleDrawerOpen = () => {
     setOpen(true);

--- a/src/hooks/editor.tsx
+++ b/src/hooks/editor.tsx
@@ -29,7 +29,7 @@ import { defaultHighlighter } from "@codemirror/next/highlight";
  */
 export function useCodeMirror(options: {
   text: string;
-  dispatch: (code: string) => void;
+  setCode: (code: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const jsCompletions = "break case catch class const continue debugger default delete do else enum export extends false finally for function if implements import interface in instanceof let new package private protected public return static super switch this throw true try typeof var void while with yield"
@@ -88,7 +88,9 @@ export function useCodeMirror(options: {
     let myView = new EditorView({
       state: editorState,
       dispatch: (t: Transaction) => {
-        options.dispatch(t.docs.toString());
+        if (t.docChanged) {
+          options.setCode(t.doc.toString());
+        }
         myView.update([t]);
       },
     });


### PR DESCRIPTION
I noticed an issue where sometimes a transaction comes through that doesn't change the document (`t.doc` is blank) which causes code to be undefined. Prior to this you could reproduce it by clicking in and out of codemirror (then trying to run your code).