### PR TITLE
oops, we double stringified

### DIFF
--- a/server/datasources/sessions.ts
+++ b/server/datasources/sessions.ts
@@ -56,11 +56,9 @@ class SessionsAPI extends DataSource<Context> {
       };
     }
 
-    result = JSON.stringify(result, null, 2);
-
     // Workaround for the case where JSON.stringify returns undefined
     // This happens with native code like console.log (Try `JSON.stringify(console.log)` yourself!)
-    if (result === undefined) {
+    if (JSON.stringify(result) === undefined) {
       result = "undefined";
     }
 


### PR DESCRIPTION
I noticed when I was playing with objects in our little REPL here that we weren't returning regular objects. This fixes it by getting rid of the extra `JSON.stringify` and using it in the check it was meant for (to catch weird native objects).